### PR TITLE
Potential fix for code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/it/unimi/dsi/fastutil/io/FastBufferedInputStream.java
+++ b/src/it/unimi/dsi/fastutil/io/FastBufferedInputStream.java
@@ -101,7 +101,7 @@ public class FastBufferedInputStream extends MeasurableInputStream implements Re
 	protected byte buffer[];
 
 	/** The current position in the buffer. */
-	protected int pos;
+	protected long pos;
 
 	/** The number of bytes ever read (reset upon a call to {@link #position(long)}).
 	 * In particular, this will always represent the index (in the underlying input stream)


### PR DESCRIPTION
Potential fix for [https://github.com/1341005547/fastutil/security/code-scanning/1](https://github.com/1341005547/fastutil/security/code-scanning/1)

To fix the issue, the type of the `pos` variable should be widened from `int` to `long`. This ensures that the compound assignment `pos += newPosition - position` does not perform an implicit narrowing conversion, as both `pos` and the result of `newPosition - position` will be of type `long`. This change will preserve the integrity of the data and prevent potential overflow or information loss.

**Steps to implement the fix:**
1. Change the type of the `pos` variable from `int` to `long` in its declaration on line 104.
2. Ensure that all usages of `pos` throughout the class are compatible with the new type (`long`). Based on the provided snippet, no additional changes are required as the operations involving `pos` appear to be arithmetic or assignments.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
